### PR TITLE
Fix Cloud Console link

### DIFF
--- a/website/docs/getting_started.html.markdown
+++ b/website/docs/getting_started.html.markdown
@@ -152,7 +152,7 @@ that it's you making the request. The preferred method of provisioning resources
 with Terraform is to use a [GCP service account](https://cloud.google.com/docs/authentication/getting-started),
 a "robot account" that can be granted a limited set of IAM permissions.
 
-From [the service account key page in the Cloud Console](https://pantheon.corp.google.com/apis/credentials/serviceaccountkey)
+From [the service account key page in the Cloud Console](https://console.cloud.google.com/apis/credentials/serviceaccountkey)
 choose an existing account, or create a new one. Next, download the JSON key
 file. Name it something you can remember, and store it somewhere secure on your
 machine.


### PR DESCRIPTION
There are apparently still ripples in the time stream from when we did our git magic, and we've got a broken link in stable-website that's not in master. But part of the commit it's in in master is already in stable-website. To make things work and be as least confusing as possible, we're going to make the change against stable-website, and it'll get overwritten by what's in master on the next release, which is fine, because the fix is already in master.