### PR TITLE
Attribute: "release_channel" shouldn't force new resource

### DIFF
--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -829,7 +829,7 @@ func resourceContainerCluster() *schema.Resource {
 
 			"release_channel": {
 				Type:     schema.TypeList,
-				ForceNew: true,
+				ForceNew: false,
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
@@ -838,7 +838,7 @@ func resourceContainerCluster() *schema.Resource {
 						"channel": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ForceNew:         true,
+							ForceNew:         false,
 							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
 							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
 						},


### PR DESCRIPTION
`release_channel` change does not require new resource to be created