### PR TITLE
Fix budget read and import functionality

### DIFF
--- a/google-beta/resource_billing_budget.go
+++ b/google-beta/resource_billing_budget.go
@@ -429,8 +429,8 @@ func resourceBillingBudgetImport(d *schema.ResourceData, meta interface{}) ([]*s
 
 	config := meta.(*Config)
 
-	// current import_formats can't import fields with forward slashes in their value
-	if err := parseImportId([]string{"(?P<project>[^ ]+) (?P<name>[^ ]+)", "(?P<name>[^ ]+)"}, d, config); err != nil {
+	// do not tokenize, the ID should be used as-is
+	if err := parseImportId([]string{"(?P<name>[^ ]+)"}, d, config); err != nil {
 		return nil, err
 	}
 

--- a/google-beta/resource_billing_budget.go
+++ b/google-beta/resource_billing_budget.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"regexp"
 	"strconv"
 	"time"
 

--- a/google-beta/resource_billing_budget.go
+++ b/google-beta/resource_billing_budget.go
@@ -337,7 +337,7 @@ func resourceBillingBudgetRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	// Terraform must set the top level schema field, but since this object contains collapsed properties
 	// it's difficult to know what the top level should be. Instead we just loop over the map returned from flatten.
-	if flattenedProp := flattenBillingBudgetBudget(res["budget"], d, config); flattenedProp != nil {
+	if flattenedProp := flattenBillingBudgetBudget(res, d, config); flattenedProp != nil {
 		if gerr, ok := flattenedProp.(*googleapi.Error); ok {
 			return fmt.Errorf("Error reading Budget: %s", gerr)
 		}


### PR DESCRIPTION
Importing a budget was not possible due to invalid ID parsing regexes (most probably just left there from copy-paste code). After this fix, the import succeeded, but it turned out that that the `resourceBillingBudgetRead` function was expected the budget attributes from the API response under a `budget` node. As the attributes are actually right in the root object, this issue prevented the resource attributes to be populated from the API response.

Would appreciate it if you could merge this into the next release.