### PR TITLE
Added v3 to module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/terraform-provider-google-beta
+module github.com/hashicorp/terraform-provider-google-beta/v3
 
 require (
 	cloud.google.com/go/bigtable v1.5.0

--- a/google-beta/provider.go
+++ b/google-beta/provider.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-google-beta/version"
+	"github.com/hashicorp/terraform-provider-google-beta/v3/version"
 
 	googleoauth "golang.org/x/oauth2/google"
 )

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta"
+	"github.com/hashicorp/terraform-provider-google-beta/v3/google-beta"
 )
 
 func main() {


### PR DESCRIPTION
This satisfies semantic versioning requirements of golang. See https://github.com/golang/go/wiki/Modules#semantic-import-versioning

This is done to be consistent with https://github.com/hashicorp/terraform-provider-google/pull/7982