### PR TITLE
Corrected version.ProviderVersion path (2/2)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ test: fmtcheck generate
 	go test $(TESTARGS) -timeout=30s $(TEST)
 
 testacc: fmtcheck
-	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc"
+	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/v3/version.ProviderVersion=acc"
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."


### PR DESCRIPTION
This change makes tests run with `make testacc` correctly set the provider version to "acc" instead of "dev". The path changed because of https://github.com/hashicorp/terraform-provider-google-beta/pull/2770.


Part 1: https://github.com/hashicorp/terraform-provider-google/pull/8398

b/179263738