### PR TITLE
Fixed repeating changes google_service_usage_consumer_quota_override when override_value is 0

### DIFF
--- a/.changelog/4522.txt
+++ b/.changelog/4522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed repeating changes google_service_usage_consumer_quota_override when override_value is 0
+```

--- a/.changelog/4522.txt
+++ b/.changelog/4522.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-Fixed repeating changes google_service_usage_consumer_quota_override when override_value is 0
-```

--- a/google-beta/resource_service_usage_consumer_quota_override.go
+++ b/google-beta/resource_service_usage_consumer_quota_override.go
@@ -363,6 +363,9 @@ func resourceServiceUsageConsumerQuotaOverrideImport(d *schema.ResourceData, met
 }
 
 func flattenNestedServiceUsageConsumerQuotaOverrideOverrideValue(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return "0"
+	}
 	return v
 }
 


### PR DESCRIPTION
Resource `google_service_usage_consumer_quota_override` created with `override_value = 0` is repeating changes.
```
  # google_service_usage_consumer_quota_override.consumer_quota["nvidia_a100_gpus"] will be updated in-place
  ~ resource "google_service_usage_consumer_quota_override" "consumer_quota" {
        dimensions     = {}
        force          = true
        id             = "projects/admin-team-dev-01/services/compute.googleapis.com/consumerQuotaMetrics/compute.googleapis.com%2Fnvidia_a100_gpus/limits/%2Fproject%2Fregion/consumerOverrides/Cg1RdW90YU92ZXJyaWRl"
        limit          = "%2Fproject%2Fregion"
        metric         = "compute.googleapis.com%2Fnvidia_a100_gpus"
        name           = "Cg1RdW90YU92ZXJyaWRl"
      + override_value = "0"
        project        = "admin-team-dev-01"
        service        = "compute.googleapis.com"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
This is due to strange behavior of Google Cloud Platform API. 
If a resource is created with `"overrideValue": "0"`, then `overrideValue` is not stored in the API object at all.
```
$ gcurl "https://serviceusage.googleapis.com/v1beta1/${REGIONAL_LIMIT_RESOURCE_NAME}/consumerOverrides"
{
  "overrides": [
    {
      "name": "projects/428822275229/services/compute.googleapis.com/consumerQuotaMetrics/compute.googleapis.com%2Fnvidia_a100_gpus/limits/%2Fproject%2Fregion/consumerOverrides/Cg1RdW90YU92ZXJyaWRlGhIKBnJlZ2lvbhIIdXMtZWFzdDQ=",
      "dimensions": {
        "region": "us-east4"
      }
    }
  ]
}
```
If `overrideValue` not equals 0, then is stored in object.
```
{
  "overrides": [
    {
      "name": "projects/428822275229/services/compute.googleapis.com/consumerQuotaMetrics/compute.googleapis.com%2Fnvidia_a100_gpus/limits/%2Fproject%2Fregion/consumerOverrides/Cg1RdW90YU92ZXJyaWRlGhIKBnJlZ2lvbhIIdXMtZWFzdDQ=",
      "overrideValue": "1",
      "dimensions": {
        "region": "us-east4"
      }
    }
  ]
}
```
```release-note:bug
serviceusage: fixed an issue in `google_service_usage_consumer_quota_override` where setting the `override_value` to 0 would result in a permanent diff
```