### PR TITLE
Allow Dataflow flex template jobs to be updated

### DIFF
--- a/google-beta/resource_dataflow_job.go
+++ b/google-beta/resource_dataflow_job.go
@@ -356,7 +356,7 @@ func resourceDataflowJobRead(d *schema.ResourceData, meta interface{}) error {
 // Stream update method. Batch job changes should have been set to ForceNew via custom diff
 func resourceDataflowJobUpdateByReplacement(d *schema.ResourceData, meta interface{}) error {
 	// Don't send an update request if only virtual fields have changes
-	if resourceDataflowJobIsVirtualUpdate(d) {
+	if resourceDataflowJobIsVirtualUpdate(d, resourceDataflowJob().Schema) {
 		return nil
 	}
 
@@ -580,7 +580,7 @@ func resourceDataflowJobIterateMapHasChange(mapKey string, d *schema.ResourceDat
 	return false
 }
 
-func resourceDataflowJobIsVirtualUpdate(d *schema.ResourceData) bool {
+func resourceDataflowJobIsVirtualUpdate(d *schema.ResourceData, resourceSchema map[string]*schema.Schema) bool {
 	// on_delete is the only virtual field
 	if d.HasChange("on_delete") {
 		// Check if other fields have changes, which would require an actual update request

--- a/google-beta/resource_dataflow_job.go
+++ b/google-beta/resource_dataflow_job.go
@@ -584,7 +584,6 @@ func resourceDataflowJobIsVirtualUpdate(d *schema.ResourceData, resourceSchema m
 	// on_delete is the only virtual field
 	if d.HasChange("on_delete") {
 		// Check if other fields have changes, which would require an actual update request
-		resourceSchema := resourceDataflowJob().Schema
 		for field := range resourceSchema {
 			if field == "on_delete" {
 				continue


### PR DESCRIPTION
I really need https://github.com/hashicorp/terraform-provider-google/issues/8408, so this is my attempt at adding support for it. I would be happy to add an update test as per the contribution guidelines, but the existing test jobs create jobs that fail to run due to lack of a real template image, and updates will not work without a running job. Should I fix this somehow?