### PR TITLE
enable rbac for data_fusion_instance

### DIFF
--- a/google-beta/resource_data_fusion_instance.go
+++ b/google-beta/resource_data_fusion_instance.go
@@ -61,7 +61,7 @@ of concurrent pipelines, no support for streaming pipelines, etc.
 - ENTERPRISE: Enterprise Data Fusion instance. In Enterprise type, the user will have more features
 available, such as support for streaming pipelines, higher number of concurrent pipelines, etc.
 - DEVELOPER: Developer Data Fusion instance. In Developer type, the user will have all features available but
-with restrictive capabilities. This is to help enterprises design and develop their data ingestion and integration 
+with restrictive capabilities. This is to help enterprises design and develop their data ingestion and integration
 pipelines at low cost. Possible values: ["BASIC", "ENTERPRISE", "DEVELOPER"]`,
 			},
 			"dataproc_service_account": {
@@ -86,6 +86,12 @@ pipelines at low cost. Possible values: ["BASIC", "ENTERPRISE", "DEVELOPER"]`,
 				Optional:    true,
 				Description: `Option to enable Stackdriver Monitoring.`,
 			},
+            "enable_rbac": {
+                Type:        schema.TypeBool,
+                Optional:    true,
+                ForceNew:    true,
+                Description: `Option to enable Granular Role Based Access Control.`,
+            },
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -233,6 +239,12 @@ func resourceDataFusionInstanceCreate(d *schema.ResourceData, meta interface{}) 
 	} else if v, ok := d.GetOkExists("enable_stackdriver_monitoring"); !isEmptyValue(reflect.ValueOf(enableStackdriverMonitoringProp)) && (ok || !reflect.DeepEqual(v, enableStackdriverMonitoringProp)) {
 		obj["enableStackdriverMonitoring"] = enableStackdriverMonitoringProp
 	}
+    enableRbacProp, err := expandDataFusionInstanceEnableRbac(d.Get("enable_rbac"), d, config)
+    if err != nil {
+        return err
+    } else if v, ok := d.GetOkExists("enable_rbac"); !isEmptyValue(reflect.ValueOf(enableRbacProp)) && (ok || !reflect.DeepEqual(v, enableRbacProp)) {
+        obj["enableRbac"] = enableRbacProp
+    }
 	labelsProp, err := expandDataFusionInstanceLabels(d.Get("labels"), d, config)
 	if err != nil {
 		return err
@@ -383,6 +395,9 @@ func resourceDataFusionInstanceRead(d *schema.ResourceData, meta interface{}) er
 	if err := d.Set("enable_stackdriver_logging", flattenDataFusionInstanceEnableStackdriverLogging(res["enableStackdriverLogging"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Instance: %s", err)
 	}
+	if err := d.Set("enable_rbac", flattenDataFusionInstanceEnableRbac(res["enable_rbac"], d, config)); err != nil {
+		return fmt.Errorf("Error reading Instance: %s", err)
+	}
 	if err := d.Set("enable_stackdriver_monitoring", flattenDataFusionInstanceEnableStackdriverMonitoring(res["enableStackdriverMonitoring"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Instance: %s", err)
 	}
@@ -448,6 +463,12 @@ func resourceDataFusionInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 	} else if v, ok := d.GetOkExists("enable_stackdriver_logging"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, enableStackdriverLoggingProp)) {
 		obj["enableStackdriverLogging"] = enableStackdriverLoggingProp
 	}
+    enableRbacProp, err := expandDataFusionInstanceEnableRbac(d.Get("enable_rbac"), d, config)
+    if err != nil {
+        return err
+    } else if v, ok := d.GetOkExists("enable_rbac"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, enableRbacProp)) {
+        obj["enableRbac"] = enableRbacProp
+    }
 	enableStackdriverMonitoringProp, err := expandDataFusionInstanceEnableStackdriverMonitoring(d.Get("enable_stackdriver_monitoring"), d, config)
 	if err != nil {
 		return err

--- a/website/docs/r/data_fusion_instance.html.markdown
+++ b/website/docs/r/data_fusion_instance.html.markdown
@@ -44,9 +44,9 @@ To get more information about Instance, see:
 ```hcl
 resource "google_data_fusion_instance" "basic_instance" {
   provider = google-beta
-  name = "my-instance"
-  region = "us-central1"
-  type = "BASIC"
+  name     = "my-instance"
+  region   = "us-central1"
+  type     = "BASIC"
 }
 ```
 <div class = "oics-button" style="float: right; margin: 0 0 -15px">
@@ -59,22 +59,23 @@ resource "google_data_fusion_instance" "basic_instance" {
 
 ```hcl
 resource "google_data_fusion_instance" "extended_instance" {
-  provider = google-beta
-  name = "my-instance"
-  description = "My Data Fusion instance"
-  region = "us-central1"
-  type = "BASIC"
-  enable_stackdriver_logging = true
+  provider                      = google-beta
+  name                          = "my-instance"
+  description                   = "My Data Fusion instance"
+  region                        = "us-central1"
+  type                          = "BASIC"
+  enable_stackdriver_logging    = true
   enable_stackdriver_monitoring = true
+  enable_rbac                   = true
   labels = {
     example_key = "example_value"
   }
   private_instance = true
   network_config {
-    network = "default"
+    network       = "default"
     ip_allocation = "10.89.48.0/22"
   }
-  version = "6.3.0"
+  version                  = "6.3.0"
   dataproc_service_account = data.google_app_engine_default_service_account.default.email
 }
 

--- a/website/docs/r/data_fusion_instance.html.markdown
+++ b/website/docs/r/data_fusion_instance.html.markdown
@@ -122,6 +122,10 @@ The following arguments are supported:
   (Optional)
   Option to enable Stackdriver Monitoring.
 
+* `enable_rbac` -
+  (Optional)
+  Option to enable granular role-based access control.
+  
 * `labels` -
   (Optional)
   The resource labels for instance to use to annotate any related underlying resources,


### PR DESCRIPTION
Google as recently enabled an RBAC option for Data fusion instance. We want to use it on a big project to share an instance with multiple tenants. 
So I'm happy to add my magic sauce to make it work. 

Hope all is ok.

Fix https://github.com/hashicorp/terraform-provider-google/issues/9065