### PR TITLE
Predict serviceId based on service runner location

### DIFF
--- a/google-beta/resource_endpoints_service.go
+++ b/google-beta/resource_endpoints_service.go
@@ -155,7 +155,7 @@ func predictServiceId(_ context.Context, d *schema.ResourceDiff, meta interface{
 	if !d.HasChange("openapi_config") && !d.HasChange("grpc_config") && !d.HasChange("protoc_output_base64") {
 		return nil
 	}
-	loc, err := time.LoadLocation("America/Los_Angeles")
+	loc, err := time.Location()
 	if err != nil {
 		// Timezone data may not be present on some machines, in that case skip
 		return nil


### PR DESCRIPTION
The prediction of the serviceId is based on a hard-coded location (`America/Los_Angeles`) which, when run in a different time zone can cause a date change and the prediction is off by a day. My guess might be that the initial tests were run against the `us-west2` Cloud Run location and fully in Terraform Cloud.

Example when applying following resource with the `Execution Mode` set to `Local`: 
```hcl
resource "google_endpoints_service" "openapi_service" {
  service_name = "my-service-name"
  project      = "my-gcp-projectId"
  openapi_config = sensitive(templatefile("./swagger.json", {
    host = "my-service-name"
  }))
}
```
I'm presented with the predicted service Id which is a day behind: `"2021-08-08r5" -> "2021-08-07r0"`

```hcl
  # module.my-api-cloud-endpoints-module.google_endpoints_service.openapi_service will be updated in-place
  ~ resource "google_endpoints_service" "openapi_service" {
      ~ config_id      = "2021-08-08r5" -> "2021-08-07r0"
        id             = "my-service-name"
      ~ openapi_config = (sensitive)
        # (5 unchanged attributes hidden)
    }
```

Rather than setting a hard-coded location, we are utilizing the system Location.

**Note**
I'm not a go developer and based my proposed change purely on reading the source code and finding the hopeful right use of Location from the [Go-Lang time documentation](https://pkg.go.dev/time#Time.Location).

Related issue: https://github.com/hashicorp/terraform-provider-google/issues/6713

In draft to allow for discussion around the proposed change