### PR TITLE
Add rate limit options to `google_compute_security_policy`

### DIFF
--- a/google-beta/resource_compute_security_policy.go
+++ b/google-beta/resource_compute_security_policy.go
@@ -230,7 +230,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "allow",
-							ValidateFunc: validation.StringInSlice([]string{"deny-403", "deny-404", "deny-429", "deny-502"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"deny(403)", "deny(404)", "deny(429)", "deny(502)"}, false),
 							Description:  `When a request is denied, returns the HTTP response code specified. Valid options are "deny()" where valid values for status are 403, 404, 429, and 502.`,
 						},
 						"exceed_action": {

--- a/google-beta/resource_compute_security_policy_test.go
+++ b/google-beta/resource_compute_security_policy_test.go
@@ -142,6 +142,28 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtection(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicy_withRateLimitOptions(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withRateLimitOptions(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeSecurityPolicyDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -343,6 +365,24 @@ resource "google_compute_security_policy" "policy" {
       enable = true
       rule_visibility = "STANDARD"
 	}
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withRateLimitOptions(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  rate_limit_options {
+    exceed_action = "deny-429"
+    enforce_on_key = "IP"
+    rate_limit_threshold {
+      count = 100
+      interval_sec = 60
+    }
   }
 }
 `, spName)


### PR DESCRIPTION

closes https://github.com/hashicorp/terraform-provider-google/issues/10020

similar to https://github.com/hashicorp/terraform-provider-google/issues/8984

todo:

do i need to add a pr to the main google repo to add the compute structs for `RateLimitOptions` ?