### PR TITLE
Check if nodepool created before returning error

### DIFF
--- a/google-beta/resource_container_node_pool.go
+++ b/google-beta/resource_container_node_pool.go
@@ -393,9 +393,14 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		default:
 			// leaving default case to ensure this is non blocking
 		}
-		// The resource didn't actually create
-		d.SetId("")
-		return waitErr
+		// Check if resource was created but apply timed out.
+		// Common cause for that is GCE_STOCKOUT which will wait for resources and return error after timeout,
+		// but in fact nodepool will be created so we have to capture that in state.
+		_, err = clusterNodePoolsGetCall.Do()
+		if err != nil {
+			d.SetId("")
+			return waitErr
+		}
 	}
 
 	log.Printf("[INFO] GKE NodePool %s has been created", nodePool.Name)


### PR DESCRIPTION
Current implementation of GKE_STOCKOUT not being captured in state issue from https://github.com/hashicorp/terraform-provider-google/issues/6287 doesn't seems to work. 
Error during apply is as follows:
`Error: Error waiting for creating GKE NodePool: Google Compute Engine: Not all instances running in IGM after 1m6.219216581s. Expected 40, running 1, transitioning 39. Current errors: [GCE_STOCKOUT]: Instance 'instance' creation failed: The zone 'projects/redacted/zones/us-west1-b' does not have enough resources available to fulfill the request.  '(resource type:compute)'.; (truncated).`

GCP behavior is to create a node pool in error state and keep waiting for resources to show up. This cause the node pool to be created but this fact is not captured in the state since error is returned. 

In order to fix this bug I'm proposing to re-check if node pool exist instead of simply assuming that it doesn't. This approach will prevent any type of situation like that, since the whole flow will be as follow:
- ensure node pool doesn't exist
- create the node pool
- if error, check if exist
- if exist - capture that in state
- if doesn't - return error