### PR TITLE
Add `ConflictWith` to `dns_cache_config` when GKE autopilot mode

### DIFF
--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -294,12 +294,13 @@ func resourceContainerCluster() *schema.Resource {
 							},
 						},
 						"dns_cache_config": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: addonsConfigKeys,
-							MaxItems:     1,
-							Description:  `The status of the NodeLocal DNSCache addon. It is disabled by default. Set enabled = true to enable.`,
+							Type:          schema.TypeList,
+							Optional:      true,
+							Computed:      true,
+							AtLeastOneOf:  addonsConfigKeys,
+							MaxItems:      1,
+							Description:   `The status of the NodeLocal DNSCache addon. It is disabled by default. Set enabled = true to enable.`,
+							ConflictsWith: []string{"enable_autopilot"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {


### PR DESCRIPTION
## WHAT

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/10262

Like `workload_identity_config` (https://github.com/hashicorp/terraform-provider-google-beta/blob/08dcb07531e5f6dd3926ab0834898275776bba92/google-beta/resource_container_cluster.go#L1118), `network_policy_config` (https://github.com/hashicorp/terraform-provider-google-beta/blob/08dcb07531e5f6dd3926ab0834898275776bba92/google-beta/resource_container_cluster.go#L240) or other features that are enabled by default for GKE Autopilot mode, it should configure `conflictWith` to feedback the users friendly on Terraform plans or applys.

When I try to disable it on my GKE cluster (Autopilot mode), I got this error:

```
 Error: googleapi: Error 400: Addons {"dns-cache"} are required to be enabled for Autopilot clusters., badRequest
```