### PR TITLE
Expose additional fields in resource_sql_source_representation_instance

### DIFF
--- a/google-beta/resource_sql_source_representation_instance.go
+++ b/google-beta/resource_sql_source_representation_instance.go
@@ -85,6 +85,12 @@ Defaults to 3306.`,
 				Sensitive:    true,
 				Description:  `The password for connecting to on-premises instance.`,
 			},
+			"dump_file_path": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  `The dump file to create the Cloud SQL replica.`,
+			},
 
 			"region": {
 				Type:     schema.TypeString,
@@ -357,6 +363,8 @@ func flattenSQLSourceRepresentationInstanceOnPremisesConfiguration(v interface{}
 		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(original["username"], d, config)
 	transformed["password"] =
 		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(original["password"], d, config)
+	transformed["dump_file_path"] =
+		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationDumpFilePath(original["dump_file_path"], d, config)
 	return []interface{}{transformed}
 }
 func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationHost(v interface{}, d *schema.ResourceData, config *Config) interface{} {
@@ -385,6 +393,10 @@ func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(v int
 }
 
 func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	return v
+}
+
+func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationDumpFilePath(v interface{}, d *schema.ResourceData, config *Config) interface{} {
 	return v
 }
 
@@ -432,6 +444,10 @@ func expandSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(v inte
 }
 
 func expandSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSQLSourceRepresentationInstanceOnPremisesConfigurationDumpFilePath(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/google-beta/resource_sql_source_representation_instance.go
+++ b/google-beta/resource_sql_source_representation_instance.go
@@ -72,6 +72,19 @@ func resourceSQLSourceRepresentationInstance() *schema.Resource {
 Defaults to 3306.`,
 				Default: 3306,
 			},
+			"username": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  `The username for connecting to on-premises instance.`,
+			},
+			"password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Sensitive:    true,
+				Description:  `The password for connecting to on-premises instance.`,
+			},
 
 			"region": {
 				Type:     schema.TypeString,
@@ -340,6 +353,10 @@ func flattenSQLSourceRepresentationInstanceOnPremisesConfiguration(v interface{}
 		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationHost(original["host"], d, config)
 	transformed["port"] =
 		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPort(original["port"], d, config)
+	transformed["username"] =
+		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(original["username"], d, config)
+	transformed["password"] =
+		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(original["password"], d, config)
 	return []interface{}{transformed}
 }
 func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationHost(v interface{}, d *schema.ResourceData, config *Config) interface{} {
@@ -361,6 +378,14 @@ func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPort(v interfa
 	}
 
 	return v // let terraform core handle it otherwise
+}
+
+func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	return v
+}
+
+func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	return v
 }
 
 func expandSQLSourceRepresentationInstanceName(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
@@ -399,6 +424,14 @@ func expandSQLSourceRepresentationInstanceOnPremisesConfigurationHost(v interfac
 }
 
 func expandSQLSourceRepresentationInstanceOnPremisesConfigurationPort(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/google-beta/resource_sql_source_representation_instance.go
+++ b/google-beta/resource_sql_source_representation_instance.go
@@ -85,6 +85,25 @@ Defaults to 3306.`,
 				Sensitive:    true,
 				Description:  `The password for connecting to on-premises instance.`,
 			},
+			"ca_certificate": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  `PEM representation of the trusted CA's x509 certificate.`,
+			},
+			"client_certificate": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  `PEM representation of the replica's x509 certificate.`,
+			},
+			"client_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Sensitive:    true,
+				Description:  `PEM representation of the replica's private key. The corresponsing public key is encoded in the client's certificate.`,
+			},
 			"dump_file_path": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -363,6 +382,12 @@ func flattenSQLSourceRepresentationInstanceOnPremisesConfiguration(v interface{}
 		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(original["username"], d, config)
 	transformed["password"] =
 		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(original["password"], d, config)
+	transformed["ca_certificate"] =
+		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationCaCertificate(original["ca_certificate"], d, config)
+	transformed["client_certificate"] =
+		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationClientCertificate(original["client_certificate"], d, config)
+	transformed["client_key"] =
+		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationClientKey(original["client_key"], d, config)
 	transformed["dump_file_path"] =
 		flattenSQLSourceRepresentationInstanceOnPremisesConfigurationDumpFilePath(original["dump_file_path"], d, config)
 	return []interface{}{transformed}
@@ -393,6 +418,18 @@ func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(v int
 }
 
 func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	return v
+}
+
+func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationCaCertificate(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	return v
+}
+
+func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationClientCertificate(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	return v
+}
+
+func flattenSQLSourceRepresentationInstanceOnPremisesConfigurationClientKey(v interface{}, d *schema.ResourceData, config *Config) interface{} {
 	return v
 }
 
@@ -444,6 +481,18 @@ func expandSQLSourceRepresentationInstanceOnPremisesConfigurationUsername(v inte
 }
 
 func expandSQLSourceRepresentationInstanceOnPremisesConfigurationPassword(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSQLSourceRepresentationInstanceOnPremisesConfigurationCaCertificate(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSQLSourceRepresentationInstanceOnPremisesConfigurationClientCertificate(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandSQLSourceRepresentationInstanceOnPremisesConfigurationClientKey(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 


### PR DESCRIPTION
Expose additional fields from the v1beta4 API:

Add the following members:
- `username`
- `password`
- `caCertificate`
- `clientCertificate`
- `clientKey`
- `dumpFilePath`

See also: https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#onpremisesconfiguration