### PR TITLE
Add missing HELM format in the artifact registry repository resource

### DIFF
--- a/google-beta/resource_artifact_registry_repository.go
+++ b/google-beta/resource_artifact_registry_repository.go
@@ -55,7 +55,8 @@ alpha formats if you are a member of the [alpha user group](https://cloud.google
 - NPM ([Preview](https://cloud.google.com/products#product-launch-stages))
 - PYTHON ([Preview](https://cloud.google.com/products#product-launch-stages))
 - APT ([alpha](https://cloud.google.com/products#product-launch-stages))
-- YUM ([alpha](https://cloud.google.com/products#product-launch-stages))`,
+- YUM ([alpha](https://cloud.google.com/products#product-launch-stages))
+- HELM ([alpha](https://cloud.google.com/products#product-launch-stages))`,
 			},
 			"repository_id": {
 				Type:     schema.TypeString,

--- a/website/docs/r/artifact_registry_repository.html.markdown
+++ b/website/docs/r/artifact_registry_repository.html.markdown
@@ -127,6 +127,7 @@ The following arguments are supported:
   - YUM ([alpha](https://cloud.google.com/products#product-launch-stages))
   - HELM ([alpha](https://cloud.google.com/products#product-launch-stages))
 
+
 - - -
 
 

--- a/website/docs/r/artifact_registry_repository.html.markdown
+++ b/website/docs/r/artifact_registry_repository.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
   - PYTHON ([Preview](https://cloud.google.com/products#product-launch-stages))
   - APT ([alpha](https://cloud.google.com/products#product-launch-stages))
   - YUM ([alpha](https://cloud.google.com/products#product-launch-stages))
-
+  - HELM ([alpha](https://cloud.google.com/products#product-launch-stages))
 
 - - -
 


### PR DESCRIPTION
## Description

Add the missing HELM format in the `google_artifact_registry_repository` resource.

Related to [Artifact registry documentation](https://cloud.google.com/artifact-registry/docs/helm).