### PR TITLE
Add Spot VM support to GKE Node Pools

### DIFF
--- a/google-beta/node_config.go
+++ b/google-beta/node_config.go
@@ -193,6 +193,14 @@ func schemaNodeConfig() *schema.Schema {
 					Description: `Whether the nodes are created as preemptible VM instances.`,
 				},
 
+				"spot": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					ForceNew:    true,
+					Default:     false,
+					Description: `Whether the nodes are created as spot VM instances.`,
+				},
+
 				"service_account": {
 					Type:        schema.TypeString,
 					Optional:    true,
@@ -478,6 +486,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 
 	// Preemptible Is Optional+Default, so it always has a value
 	nc.Preemptible = nodeConfig["preemptible"].(bool)
+	nc.Spot = nodeConfig["spot"].(bool)
 
 	if v, ok := nodeConfig["min_cpu_platform"]; ok {
 		nc.MinCpuPlatform = v.(string)
@@ -609,6 +618,7 @@ func flattenNodeConfig(c *container.NodeConfig) []map[string]interface{} {
 		"labels":                   c.Labels,
 		"tags":                     c.Tags,
 		"preemptible":              c.Preemptible,
+		"spot":                     c.Spot,
 		"min_cpu_platform":         c.MinCpuPlatform,
 		"shielded_instance_config": flattenShieldedInstanceConfig(c.ShieldedInstanceConfig),
 		"taint":                    flattenTaints(c.Taints),

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -676,6 +676,10 @@ gcfs_config {
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
+* `spot` - (Optional) A boolean that represents whether the underlying node VMs
+    are spot. See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms)
+    for more information. Defaults to false.
+
 * `sandbox_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods) configuration. When enabling this feature you must specify `image_type = "COS_CONTAINERD"` and `node_version = "1.12.7-gke.17"` or later to use it.
     Structure is [documented below](#nested_sandbox_config).
 


### PR DESCRIPTION
GKE Node Pools now support Spot VMs (not to be confused with Preemptible VMs):
https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms
This is not supported in web UI yet, but `gcloud` cli have it:
https://cloud.google.com/kubernetes-engine/docs/how-to/spot-vms#create_a_node_pool_with_enabled
API field `spot`: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/NodeConfig
(Also, pulumi with `google_native` provider already have the support)
