### PR TITLE
Remove "KERBEROS" from list of accepted values for "optional_components"

### DIFF
--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -492,7 +492,6 @@ cluster_config {
     * HBASE
     * HIVE_WEBHCAT
     * JUPYTER
-    * KERBEROS
     * PRESTO
     * RANGER
     * SOLR


### PR DESCRIPTION
If you try to add Kerberos to a Dataproc resource (`google_dataproc_cluster`) using the `google-beta` provider by including it in the `optional_components` list, you will receive the following error:

```
Error: Error creating Dataproc cluster: googleapi: Error 400: Enabling Kerberos via Optional Components and properties is no longer supported. Please configure Kerberos via KerberosConfig instead, badRequest
```

This patch reflects the information conveyed in this error by removing `KERBEROS` from the list of potential items that can be included in `optional_components`.

This patch is likely also relevant for the `google` provider (or will be in the near future).