### PR TITLE
Set url_mask optional for network endpoint group

### DIFF
--- a/google-beta/resource_compute_region_network_endpoint_group.go
+++ b/google-beta/resource_compute_region_network_endpoint_group.go
@@ -214,7 +214,7 @@ API Gateway: apigateway.googleapis.com`,
 						},
 						"url_mask": {
 							Type:     schema.TypeString,
-							Required: true,
+							Required: false,
 							ForceNew: true,
 							Description: `A template to parse platform-specific fields from a request URL. URL mask allows for routing to multiple resources
 on the same serverless platform without having to create multiple Network Endpoint Groups and backend resources.


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#11242

This isn't required - the gcloud command correctly creates a serverless NEG with an API gateway resource without url_mask specified.