### PR TITLE
feat: add gke_backup_agent_config to google_container_cluster

### DIFF
--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -65,6 +65,7 @@ var (
 		"addons_config.0.gce_persistent_disk_csi_driver_config",
 		"addons_config.0.kalm_config",
 		"addons_config.0.config_connector_config",
+		"addons_config.0.gke_backup_agent_config",
 	}
 
 	forceNewClusterNodeConfigFields = []string{
@@ -368,6 +369,22 @@ func resourceContainerCluster() *schema.Resource {
 							AtLeastOneOf: addonsConfigKeys,
 							MaxItems:     1,
 							Description:  `The of the Config Connector addon.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"gke_backup_agent_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Description:  `The status of the Backup for GKE Agent addon. It is disabled by default. Set enabled = true to enable.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
@@ -3040,7 +3057,13 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 			ForceSendFields: []string{"Enabled"},
 		}
 	}
-
+	if v, ok := config["gke_backup_agent_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.GkeBackupAgentConfig = &container.GkeBackupAgentConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
 	return ac
 }
 
@@ -3679,6 +3702,13 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		result["config_connector_config"] = []map[string]interface{}{
 			{
 				"enabled": c.ConfigConnectorConfig.Enabled,
+			},
+		}
+	}
+	if c.GkeBackupAgentConfig != nil {
+		result["gke_backup_agent_config"] = []map[string]interface{}{
+			{
+				"enabled": c.GkeBackupAgentConfig.Enabled,
 			},
 		}
 	}

--- a/google-beta/resource_container_cluster_test.go
+++ b/google-beta/resource_container_cluster_test.go
@@ -2574,6 +2574,9 @@ resource "google_container_cluster" "primary" {
 	config_connector_config {
 	  enabled = false
 	}
+	gke_backup_agent_config {
+		enabled = false
+	}
   }
 }
 `, projectID, clusterName)
@@ -2626,6 +2629,9 @@ resource "google_container_cluster" "primary" {
 	  enabled = true
 	}
 	config_connector_config {
+	  enabled = true
+	}
+	gke_backup_agent_config {
 	  enabled = true
 	}
   }


### PR DESCRIPTION
Add support for [GKE Backup](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke) Agent addon in google_container_cluster.

Usage:
```
resource "google_container_cluster" "gke" {
  provider = google-beta
  ...
  addons_config {
     gke_backup_agent_config {
      enabled = true
    }
  }
}
```

Tested  with Terraform v1.1.7 on linux_amd64