### PR TITLE
update dependabot to ignore version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+        # Ignore version updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major","version-update:semver-minor","version-update:semver-patch"]


### PR DESCRIPTION
I think this should ignore all version updates and still alert on security vulnerabilities per the documentation here:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore