### PR TITLE
add .release folder

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,2 @@
+url_source_repository      = "https://github.com/hashicorp/terraform-provider-google-beta"
+url_license                = "https://github.com/hashicorp/terraform-provider-google-beta/blob/main/LICENSE"


### PR DESCRIPTION
adding this in because we need the `.release` folder to exist before we can generate the `release-metadata.hcl` file