### PR TITLE
Switched off GOGC for linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 4m
+  timeout: 5m
 
 linters:
   disable-all: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ fmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	@golangci-lint run ./$(DIR_NAME)
+	@GOGC=off golangci-lint run -v ./$(DIR_NAME)
 
 tools:
 	@echo "==> installing required tooling..."


### PR DESCRIPTION
This will increase memory usage but should decrease run time if memory isn't the bottleneck - see https://golangci-lint.run/usage/performance/

Also enabled verbose logging for the linter so that we can see how far it gets and what is slow when it times out.

Also increased the timeout