### PR TITLE
Fix user-agent bug due to goreleaser ldflags not overriding value in release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
       - goarch: arm64
         goos: windows
     ldflags:
-      - -s -w -X version.ProviderVersion={{.Version}}
+      - -s -w -X github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   extra_files:


### PR DESCRIPTION
# Description

Partially closes https://github.com/hashicorp/terraform-provider-google/issues/13196

This PR is the TPGB version of this PR in TPG : https://github.com/hashicorp/terraform-provider-google/pull/13197

The diff for this PR includes `-beta`