### PR TITLE
Add changelog for 4.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ FEATURES:
 * **New Data Source:** `google_secret_manager_secret_version_access` ([#5147](https://github.com/hashicorp/terraform-provider-google-beta/pull/5147))
 * **New Resource:** `google_cloudbuildv2_connection` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
 * **New Resource:** `google_cloudbuildv2_repository` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
-* **New Resource:** google_workstations_workstation_cluster ([#5154](https://github.com/hashicorp/terraform-provider-google-beta/pull/5154))
+* **New Resource:** `google_workstations_workstation_cluster` ([#5154](https://github.com/hashicorp/terraform-provider-google-beta/pull/5154))
 
 IMPROVEMENTS:
-* Updated the `settings.deletion_protection_enabled` property documentation. ([#5137](https://github.com/hashicorp/terraform-provider-google-beta/pull/5137))
-* bigquery: Added support for federated Azure identities to BigQuery Omni connections. ([#5150](https://github.com/hashicorp/terraform-provider-google-beta/pull/5150))
+* sql: updated the `settings.deletion_protection_enabled` property documentation. ([#13581](https://github.com/hashicorp/terraform-provider-google/pull/13581))
+* bigquery: added support for federated Azure identities to BigQuery Omni connections. ([#5150](https://github.com/hashicorp/terraform-provider-google-beta/pull/5150))
 * bigquery: added `cloud_spanner.use_serverless_analytics` field ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
 * bigquery: added `cloud_sql.service_account_id` and `azure.identity` output fields ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
 * cloudbuild: added field `repository_event_config` to resource `trigger` (beta) ([#5142](https://github.com/hashicorp/terraform-provider-google-beta/pull/5142))
@@ -16,7 +16,7 @@ IMPROVEMENTS:
 * sql: made `root_password` field updatable in `google_sql_database_instance` ([#5133](https://github.com/hashicorp/terraform-provider-google-beta/pull/5133))
 
 BUG FIXES:
-* GCF: modify max_instances field to take API's result as default value ([#5134](https://github.com/hashicorp/terraform-provider-google-beta/pull/5134))
+* cloudfunctions: updated max_instances field to take API's result as default value ([#13575](https://github.com/hashicorp/terraform-provider-google/pull/13575))
 * container: fixed an issue with resuming failed cluster creation ([#5136](https://github.com/hashicorp/terraform-provider-google-beta/pull/5136))
 * datacatalog: fixed the import failure when the `project` is different from the default on `google_data_catalog_taxonomy` ([#5145](https://github.com/hashicorp/terraform-provider-google-beta/pull/5145))
 * secretmanager: fixed incorrect required_with for topics in `google_secret_managed_secret` ([#5149](https://github.com/hashicorp/terraform-provider-google-beta/pull/5149))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 FEATURES:
 * **New Data Source:** `google_secret_manager_secret_version_access` ([#5147](https://github.com/hashicorp/terraform-provider-google-beta/pull/5147))
-* **New Resource:** `google_cloudbuildv2_connection` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
-* **New Resource:** `google_cloudbuildv2_repository` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
+* **New Resource:** `google_cloudbuildv2_connection` ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
+* **New Resource:** `google_cloudbuildv2_repository` ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
 * **New Resource:** `google_workstations_workstation_cluster` ([#5154](https://github.com/hashicorp/terraform-provider-google-beta/pull/5154))
 
 IMPROVEMENTS:
-* sql: updated the `settings.deletion_protection_enabled` property documentation. ([#13581](https://github.com/hashicorp/terraform-provider-google-beta/pull/13581))
 * bigquery: added support for federated Azure identities to BigQuery Omni connections. ([#5150](https://github.com/hashicorp/terraform-provider-google-beta/pull/5150))
 * bigquery: added `cloud_spanner.use_serverless_analytics` field ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
 * bigquery: added `cloud_sql.service_account_id` and `azure.identity` output fields ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
-* cloudbuild: added field `repository_event_config` to resource `trigger` (beta) ([#5142](https://github.com/hashicorp/terraform-provider-google-beta/pull/5142))
+* cloudbuild: added field `repository_event_config` to resource `trigger` ([#5142](https://github.com/hashicorp/terraform-provider-google-beta/pull/5142))
 * compute: added `locality_lb_policies` field to `google_compute_backend_service` ([#5146](https://github.com/hashicorp/terraform-provider-google-beta/pull/5146))
+* sql: updated the `settings.deletion_protection_enabled` property documentation. ([#13581](https://github.com/hashicorp/terraform-provider-google-beta/pull/13581))
 * sql: made `root_password` field updatable in `google_sql_database_instance` ([#5133](https://github.com/hashicorp/terraform-provider-google-beta/pull/5133))
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## 4.52.0 (Unreleased)
 
+FEATURES:
+* **New Data Source:** `google_secret_manager_secret_version_access` ([#5147](https://github.com/hashicorp/terraform-provider-google-beta/pull/5147))
+* **New Resource:** `google_cloudbuildv2_connection` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
+* **New Resource:** `google_cloudbuildv2_repository` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
+* **New Resource:** google_workstations_workstation_cluster ([#5154](https://github.com/hashicorp/terraform-provider-google-beta/pull/5154))
+
+IMPROVEMENTS:
+* Updated the `settings.deletion_protection_enabled` property documentation. ([#5137](https://github.com/hashicorp/terraform-provider-google-beta/pull/5137))
+* bigquery: Added support for federated Azure identities to BigQuery Omni connections. ([#5150](https://github.com/hashicorp/terraform-provider-google-beta/pull/5150))
+* bigquery: added `cloud_spanner.use_serverless_analytics` field ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
+* bigquery: added `cloud_sql.service_account_id` and `azure.identity` output fields ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
+* cloudbuild: added field `repository_event_config` to resource `trigger` (beta) ([#5142](https://github.com/hashicorp/terraform-provider-google-beta/pull/5142))
+* compute: added `locality_lb_policies` field to `google_compute_backend_service` ([#5146](https://github.com/hashicorp/terraform-provider-google-beta/pull/5146))
+* sql: made `root_password` field updatable in `google_sql_database_instance` ([#5133](https://github.com/hashicorp/terraform-provider-google-beta/pull/5133))
+
+BUG FIXES:
+* GCF: modify max_instances field to take API's result as default value ([#5134](https://github.com/hashicorp/terraform-provider-google-beta/pull/5134))
+* container: fixed an issue with resuming failed cluster creation ([#5136](https://github.com/hashicorp/terraform-provider-google-beta/pull/5136))
+* datacatalog: fixed the import failure when the `project` is different from the default on `google_data_catalog_taxonomy` ([#5145](https://github.com/hashicorp/terraform-provider-google-beta/pull/5145))
+* secretmanager: fixed incorrect required_with for topics in `google_secret_managed_secret` ([#5149](https://github.com/hashicorp/terraform-provider-google-beta/pull/5149))
+
 ## 4.51.0 (January 30, 2023)
 
 DEPRECATIONS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ FEATURES:
 * **New Resource:** `google_workstations_workstation_cluster` ([#5154](https://github.com/hashicorp/terraform-provider-google-beta/pull/5154))
 
 IMPROVEMENTS:
-* sql: updated the `settings.deletion_protection_enabled` property documentation. ([#13581](https://github.com/hashicorp/terraform-provider-google/pull/13581))
+* sql: updated the `settings.deletion_protection_enabled` property documentation. ([#13581](https://github.com/hashicorp/terraform-provider-google-beta/pull/13581))
 * bigquery: added support for federated Azure identities to BigQuery Omni connections. ([#5150](https://github.com/hashicorp/terraform-provider-google-beta/pull/5150))
 * bigquery: added `cloud_spanner.use_serverless_analytics` field ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
 * bigquery: added `cloud_sql.service_account_id` and `azure.identity` output fields ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
@@ -16,7 +16,7 @@ IMPROVEMENTS:
 * sql: made `root_password` field updatable in `google_sql_database_instance` ([#5133](https://github.com/hashicorp/terraform-provider-google-beta/pull/5133))
 
 BUG FIXES:
-* cloudfunctions: updated max_instances field to take API's result as default value ([#13575](https://github.com/hashicorp/terraform-provider-google/pull/13575))
+* cloudfunctions: updated max_instances field to take API's result as default value ([#13575](https://github.com/hashicorp/terraform-provider-google-beta/pull/13575))
 * container: fixed an issue with resuming failed cluster creation ([#5136](https://github.com/hashicorp/terraform-provider-google-beta/pull/5136))
 * datacatalog: fixed the import failure when the `project` is different from the default on `google_data_catalog_taxonomy` ([#5145](https://github.com/hashicorp/terraform-provider-google-beta/pull/5145))
 * secretmanager: fixed incorrect required_with for topics in `google_secret_managed_secret` ([#5149](https://github.com/hashicorp/terraform-provider-google-beta/pull/5149))


### PR DESCRIPTION
changelog-gen output:

Deletions below show where I removed the changelog created for the PR when updating changelog.md after the v4.51.0 release
Additions below show lines that I've edited for formatting

```diff
- UNKNOWN CHANGELOG TYPE:
- * Update changelog for v4.51.0 ([#5144](https://github.com/hashicorp/terraform-provider-google-beta/pull/5144))

FEATURES:
* **New Data Source:** `google_secret_manager_secret_version_access` ([#5147](https://github.com/hashicorp/terraform-provider-google-beta/pull/5147))
* **New Resource:** `google_cloudbuildv2_connection` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
* **New Resource:** `google_cloudbuildv2_repository` (beta) ([#5140](https://github.com/hashicorp/terraform-provider-google-beta/pull/5140))
+ * **New Resource:** google_workstations_workstation_cluster ([#5154](https://github.com/hashicorp/terraform-provider-google-beta/pull/5154))

IMPROVEMENTS:
+ * Updated the `settings.deletion_protection_enabled` property documentation. ([#5137](https://github.com/hashicorp/terraform-provider-google-beta/pull/5137))
+ * bigquery: Added support for federated Azure identities to BigQuery Omni connections. ([#5150](https://github.com/hashicorp/terraform-provider-google-beta/pull/5150))
* bigquery: added `cloud_spanner.use_serverless_analytics` field ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
* bigquery: added `cloud_sql.service_account_id` and `azure.identity` output fields ([#5139](https://github.com/hashicorp/terraform-provider-google-beta/pull/5139))
* cloudbuild: added field `repository_event_config` to resource `trigger` (beta) ([#5142](https://github.com/hashicorp/terraform-provider-google-beta/pull/5142))
* compute: added `locality_lb_policies` field to `google_compute_backend_service` ([#5146](https://github.com/hashicorp/terraform-provider-google-beta/pull/5146))
* sql: made `root_password` field updatable in `google_sql_database_instance` ([#5133](https://github.com/hashicorp/terraform-provider-google-beta/pull/5133))

BUG FIXES:
+ * GCF: modify max_instances field to take API's result as default value ([#5134](https://github.com/hashicorp/terraform-provider-google-beta/pull/5134))
* container: fixed an issue with resuming failed cluster creation ([#5136](https://github.com/hashicorp/terraform-provider-google-beta/pull/5136))
* datacatalog: fixed the import failure when the `project` is different from the default on `google_data_catalog_taxonomy` ([#5145](https://github.com/hashicorp/terraform-provider-google-beta/pull/5145))
* secretmanager: fixed incorrect required_with for topics in `google_secret_managed_secret` ([#5149](https://github.com/hashicorp/terraform-provider-google-beta/pull/5149))
```