### PR TITLE
Update LICENSE to include correct year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 HashiCorp, Inc.
+Copyright (c) 2017 HashiCorp, Inc.
 
 Mozilla Public License Version 2.0
 ==================================


### PR DESCRIPTION
Updating the copyright year in the `google-beta` provider repo to match the copyright year in the `google` provider repo (see this PR: https://github.com/hashicorp/terraform-provider-google/pull/12777)

This makes the copyright year match the initial commit in this repo (https://github.com/hashicorp/terraform-provider-google-beta/commit/5d420e83f60e2f76403518390c84e970940cdcf0), which is shared between both repos.

Note: I got guidance from #proj-software-copyright about this change.