### PR TITLE
update data policy api version

### DIFF
--- a/google-beta/config.go
+++ b/google-beta/config.go
@@ -415,7 +415,7 @@ var DefaultBasePaths = map[string]string{
 	BigQueryBasePathKey:             "https://bigquery.googleapis.com/bigquery/v2/",
 	BigqueryAnalyticsHubBasePathKey: "https://analyticshub.googleapis.com/v1beta1/",
 	BigqueryConnectionBasePathKey:   "https://bigqueryconnection.googleapis.com/v1/",
-	BigqueryDatapolicyBasePathKey:   "https://bigquerydatapolicy.googleapis.com/v1beta1/",
+	BigqueryDatapolicyBasePathKey:   "https://bigquerydatapolicy.googleapis.com/v1/",
 	BigqueryDataTransferBasePathKey: "https://bigquerydatatransfer.googleapis.com/v1/",
 	BigqueryReservationBasePathKey:  "https://bigqueryreservation.googleapis.com/v1/",
 	BigtableBasePathKey:             "https://bigtableadmin.googleapis.com/v2/",

--- a/google-beta/resource_bigquery_datapolicy_data_policy.go
+++ b/google-beta/resource_bigquery_datapolicy_data_policy.go
@@ -76,8 +76,9 @@ func ResourceBigqueryDatapolicyDataPolicy() *schema.Resource {
 						"predefined_expression": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validateEnum([]string{"SHA256", "ALWAYS_NULL", "DEFAULT_MASKING_VALUE"}),
-							Description:  `The available masking rules. Learn more here: https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options. Possible values: ["SHA256", "ALWAYS_NULL", "DEFAULT_MASKING_VALUE"]`,
+							ValidateFunc: validateEnum([]string{"SHA256", "ALWAYS_NULL", "DEFAULT_MASKING_VALUE", "LAST_FOUR_CHARACTERS", "FIRST_FOUR_CHARACTERS", "EMAIL_MASK", "DATE_YEAR_MASK"}),
+							Description: `The available masking rules. Learn more here: https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options. \
+							               Possible values: ["SHA256", "ALWAYS_NULL", "DEFAULT_MASKING_VALUE", "LAST_FOUR_CHARACTERS", "FIRST_FOUR_CHARACTERS", "EMAIL_MASK", "DATE_YEAR_MASK"]`,
 						},
 					},
 				},

--- a/website/docs/r/bigquery_datapolicy_data_policy.html.markdown
+++ b/website/docs/r/bigquery_datapolicy_data_policy.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 * `predefined_expression` -
   (Required)
   The available masking rules. Learn more here: https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options.
-  Possible values are `SHA256`, `ALWAYS_NULL`, and `DEFAULT_MASKING_VALUE`.
+  Possible values are `SHA256`, `ALWAYS_NULL`, `DEFAULT_MASKING_VALUE`, `LAST_FOUR_CHARACTERS`, `FIRST_FOUR_CHARACTERS`, `EMAIL_MASK`, `DATE_YEAR_MASK` and `DEFAULT_MASKING_VALUE`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Follow up [13867](https://github.com/hashicorp/terraform-provider-google/issues/13867)
It'll be possible to use additional masking policy if Data policy API version is upgraded.
https://cloud.google.com/bigquery/docs/reference/bigquerydatapolicy/rest/v1/projects.locations.dataPolicies#PredefinedExpression:~:text=predefined%20masking%20expression.-,PredefinedExpression,-The%20available%20masking