### PR TITLE
Remove extraneous error message during docscheck when searching for unused file type

### DIFF
--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docs=$(ls website/docs/**/*.markdown website/docs/**/*.md)
+docs=$(ls website/docs/**/*.markdown)
 error=false
 
 for doc in $docs; do


### PR DESCRIPTION
We already made this change to terraform-provider-google: https://github.com/hashicorp/terraform-provider-google/pull/8353

There appears to have been a transition away from `.md` files, and so we don't need to list them during the check. This removes a benign error that would show up in the logs: `ls: website/docs/**/*.md: No such file or directory`

