### PR TITLE
Add check for Environment proto field before accessing

### DIFF
--- a/google-beta/services/dataflow/resource_dataflow_job.go
+++ b/google-beta/services/dataflow/resource_dataflow_job.go
@@ -372,6 +372,9 @@ func resourceDataflowJobRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("effective_labels", job.Labels); err != nil {
 		return fmt.Errorf("Error setting effective_labels: %s", err)
 	}
+	if job.Environment == nil {
+		return fmt.Errorf("Error setting kms_key_name: proto Environment field is nil")
+	}
 	if err := d.Set("kms_key_name", job.Environment.ServiceKmsKeyName); err != nil {
 		return fmt.Errorf("Error setting kms_key_name: %s", err)
 	}


### PR DESCRIPTION
Checks for the existence of the environment proto field before accessing a nested field, avoiding a nil-pointer exception if the environment proto is nil. 

Fixes #17046