### PR TITLE
chore(ci): Update .goreleaser.yml to include LICENSE.txt file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,8 @@
 archives:
   - files:
       # Include built binary and license files in archive
-      - 'LICENSE'
+      - src: 'LICENSE'
+        dst: 'LICENSE.txt'
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 builds:


### PR DESCRIPTION
Adding LICENSE.txt file to Terraform Provider Release Archives
