### PR TITLE
add `.github/workflows/teamcity-nightly-workflow.yaml`

### DIFF
--- a/.github/workflows/teamcity-nightly-workflow.yml
+++ b/.github/workflows/teamcity-nightly-workflow.yml
@@ -1,0 +1,15 @@
+name: "TeamCity: Create empty branch off tip of main to aid nightly-testing"
+
+
+# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 4 * * *'
+
+jobs:
+    # uses the same teamcity nightly workflow used in terraform-provider-google
+    # as well as the default value for DAYS_THRESHOLD
+    tpg-nightly-workflow:
+        uses: hashicorp/terraform-provider-google/.github/workflows/teamcity-nightly-workflow.yaml@main


### PR DESCRIPTION
reuses the workflow from `terraform-provider-google` provider: https://github.com/hashicorp/terraform-provider-google/pull/18241

GHA runs:

Successful creation of branch along with a successful sweep due to no branches existing to sweep: https://github.com/BBBmau/terraform-provider-google-beta/actions/runs/9454427354

Failure due to branch already existing: https://github.com/BBBmau/terraform-provider-google-beta/actions/runs/9454439393