### PR TITLE
Update 4.85.0 CHANGELOG to main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1017,8 +1017,13 @@ BUG FIXES:
 * vertexai: made `contents_delta_uri` a required field in `google_vertex_ai_index` as omitting it would result in an error ([#6374](https://github.com/hashicorp/terraform-provider-google-beta/pull/6374))
 * workstations: fixed in-place updates of `host.gce_instance.accelerators` in `google_workstation_config` ([#6354](https://github.com/hashicorp/terraform-provider-google-beta/pull/6354))
 
+## 4.85.0 (June 12, 2024)
 
+NOTES:
+* The `4.85.0` release backports configuration for the retention period for Cloud Storage soft delete (https://cloud.google.com/resources/storage/soft-delete-announce) so that customers who have not yet upgraded to `5.22.0`+ are able to configure the retention period of objects in their buckets. By upgrading to this version and configuring or otherwise interacting with the `google_storage_bucket.soft_delete_policy` values, you will need to upgrade directly to `5.22.0`+ from `4.85.0` when upgrading to `5.X` in the future.
 
+IMPROVEMENTS:
+* storage: added `soft_delete_policy` to `google_storage_bucket` resource ([#7119](https://github.com/hashicorp/terraform-provider-google-beta/pull/7119))
 
 ## 4.84.0 (September 26, 2023)
 


### PR DESCRIPTION
Update 4.85.0 CHANGELOG to main branch to backport configuration for the retention period for Cloud Storage soft delete