### PR TITLE
TeamCity: update nightly workflow to use static branch

### DIFF
--- a/.github/workflows/teamcity-nightly-sweeper.yaml
+++ b/.github/workflows/teamcity-nightly-sweeper.yaml
@@ -1,6 +1,6 @@
 name: "TeamCity: Remove branches used for nightly test"
 
-# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
+# TeamCity should use a newly created branches that matches the pattern `UTC-<YYYY-MM-DD>` and is the only branch matching that pattern. We rename past nightly test branches to avoid there being more than one `UTC-<YYYY-MM-DD>` branch (i.e. only one branch that matches the filter (+:UTC-*,-:UTC-nightly-tests*)). This workflow also removes renamed branches once they get past a certain age. 
 
 on:
     workflow_dispatch:

--- a/.github/workflows/teamcity-nightly-sweeper.yaml
+++ b/.github/workflows/teamcity-nightly-sweeper.yaml
@@ -1,15 +1,14 @@
-name: "TeamCity: Create empty branch off tip of main to aid nightly-testing"
-
+name: "TeamCity: Remove branches used for nightly test"
 
 # To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
 
 on:
     workflow_dispatch:
     schedule:
-        - cron: '0 4 * * *'
+        - cron: '0 9 * * *' # UTC 9AM (-7)-> 2PM PST
 
 jobs:
     # uses the same teamcity nightly workflow used in terraform-provider-google
     # as well as the default value for DAYS_THRESHOLD
     tpg-teamcity-nightly-workflow:
-        uses: hashicorp/terraform-provider-google/.github/workflows/teamcity-nightly-workflow.yaml@main
+        uses: hashicorp/terraform-provider-google/.github/workflows/teamcity-nightly-sweeper.yaml@main

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -1,6 +1,6 @@
 name: "TeamCity: Create empty branch off tip of main to aid nightly-testing"
 
-# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
+# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on. This branch will have the name `UTC-<YYYY-MM-DD>` and contains the current date at time of creation.
 
 on:
     workflow_dispatch:

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -1,0 +1,14 @@
+name: "TeamCity: Create empty branch off tip of main to aid nightly-testing"
+
+# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 3 * * *' # 3AM UTC (-7)-> 8PM PST # teamcity builds are triggered @ 4AM UTC
+
+jobs:
+    # uses the same teamcity nightly workflow used in terraform-provider-google
+    # as well as the default value for DAYS_THRESHOLD
+    tpg-teamcity-nightly-workflow:
+        uses: hashicorp/terraform-provider-google/.github/workflows/teamcity-nightly-workflow.yaml@main

--- a/.github/workflows/teamcity-nightly-workflow.yml
+++ b/.github/workflows/teamcity-nightly-workflow.yml
@@ -1,0 +1,15 @@
+name: "TeamCity: Create empty branch off tip of main to aid nightly-testing"
+
+
+# To ensure nightly tests/builds run on the same commit, we checkout and create a new branch from main for TeamCity to run builds on
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 4 * * *'
+
+jobs:
+    # uses the same teamcity nightly workflow used in terraform-provider-google
+    # as well as the default value for DAYS_THRESHOLD
+    tpg-nightly-workflow:
+        uses: hashicorp/terraform-provider-google/.github/workflows/teamcity-nightly-workflow.yaml@main

--- a/.github/workflows/teamcity-nightly-workflow.yml
+++ b/.github/workflows/teamcity-nightly-workflow.yml
@@ -11,5 +11,5 @@ on:
 jobs:
     # uses the same teamcity nightly workflow used in terraform-provider-google
     # as well as the default value for DAYS_THRESHOLD
-    tpg-nightly-workflow:
+    tpg-teamcity-nightly-workflow:
         uses: hashicorp/terraform-provider-google/.github/workflows/teamcity-nightly-workflow.yaml@main


### PR DESCRIPTION
applying changes made on `terraform-provider-google` which allows the ability to use a static branch filter for teamcity triggered builds.

More can be read here: https://github.com/hashicorp/terraform-provider-google/pull/18447