### PR TITLE
fix missing alias for name secret_ref (hashicorp#21272)

### DIFF
--- a/google-beta/services/cloudrun/resource_cloud_run_service.go
+++ b/google-beta/services/cloudrun/resource_cloud_run_service.go
@@ -1240,7 +1240,8 @@ version or an integer for a specific version.`,
 										Required: true,
 										Description: `The name of the secret in Cloud Secret Manager. By default, the secret is assumed to be in the same project.
 If the secret is in another project, you must define an alias.
-An alias definition has the form: :projects/{project-id|project-number}/secrets/.
+An alias definition has the form:
+{alias}:projects/{project-id|project-number}/secrets/{secret-name}.
 If multiple alias definitions are needed, they must be separated by commas.
 The alias definitions must be set on the run.googleapis.com/secrets annotation.`,
 									},

--- a/website/docs/r/cloud_run_service.html.markdown
+++ b/website/docs/r/cloud_run_service.html.markdown
@@ -624,7 +624,8 @@ The following arguments are supported:
   (Required)
   The name of the secret in Cloud Secret Manager. By default, the secret is assumed to be in the same project.
   If the secret is in another project, you must define an alias.
-  An alias definition has the form: :projects/{project-id|project-number}/secrets/.
+  An alias definition has the form:
+  {alias}:projects/{project-id|project-number}/secrets/{secret-name}.
   If multiple alias definitions are needed, they must be separated by commas.
   The alias definitions must be set on the run.googleapis.com/secrets annotation.
 


### PR DESCRIPTION
fix missing alias for name secret_ref (hashicorp#21272)

fixes https://github.com/hashicorp/terraform-provider-google/issues/21272