### PR TITLE
Broken Provider

### DIFF
--- a/ISSUE.md
+++ b/ISSUE.md
@@ -1,0 +1,14 @@
+# Issue
+Getting error in Terraform Cloud with this provider:
+```
+Provider registry.terraform.io/hashicorp/google-beta v6.21.0 does not have a
+package available for your current platform, linux_amd64
+```
+
+Your repo doesn't allow issues, so here's a PR to tell you about it.
+
+---
+
+It is also being reported in the `#terraform` channel of the Google Cloud
+Platform Community Slack:
+https://googlecloud-community.slack.com/archives/C1VNJ4EG7/p1739970828700649


### PR DESCRIPTION
# Issue
Getting error in Terraform Cloud with this provider:
```
Provider registry.terraform.io/hashicorp/google-beta v6.21.0 does not have a
package available for your current platform, linux_amd64
```

Your repo doesn't allow issues, so here's a PR to tell you about it.

---

It is also being reported in the `#terraform` channel of the Google Cloud
Platform Community Slack:
https://googlecloud-community.slack.com/archives/C1VNJ4EG7/p1739970828700649