### PR TITLE
Added additionalPipelineOptions to google_dataflow_flex_template_job

### DIFF
--- a/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
+++ b/google-beta/services/dataflow/resource_dataflow_flex_template_job.go
@@ -223,6 +223,15 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 				},
 			},
 
+			"additional_pipeline_options": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: `List of pipeline options that should be used by the job. An example value is ["numberOfWorkerHarnessThreads=20"].`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"enable_streaming_engine": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -314,6 +323,8 @@ func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_t
 
 	additionalExperiments := tpgresource.ConvertStringSet(d.Get("additional_experiments").(*schema.Set))
 
+	additionalPipelineOptions := tpgresource.ConvertStringSet(d.Get("additional_pipeline_options").(*schema.Set))
+
 	var autoscalingAlgorithm string
 	autoscalingAlgorithm, updatedParameters = dataflowFlexJobTypeTransferVar("autoscaling_algorithm", "autoscalingAlgorithm", updatedParameters, d)
 
@@ -384,22 +395,23 @@ func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_t
 	launcherMachineType, updatedParameters := dataflowFlexJobTypeTransferVar("launcher_machine_type", "launcherMachineType", updatedParameters, d)
 
 	env := dataflow.FlexTemplateRuntimeEnvironment{
-		AdditionalUserLabels:  tpgresource.ExpandStringMap(d, "effective_labels"),
-		AutoscalingAlgorithm:  autoscalingAlgorithm,
-		NumWorkers:            int64(numWorkers),
-		MaxWorkers:            int64(maxNumWorkers),
-		Network:               network,
-		ServiceAccountEmail:   serviceAccountEmail,
-		Subnetwork:            subnetwork,
-		TempLocation:          tempLocation,
-		StagingLocation:       stagingLocation,
-		MachineType:           machineType,
-		KmsKeyName:            kmsKeyName,
-		IpConfiguration:       ipConfiguration,
-		EnableStreamingEngine: enableStreamingEngine,
-		AdditionalExperiments: additionalExperiments,
-		SdkContainerImage:     sdkContainerImage,
-		LauncherMachineType:   launcherMachineType,
+		AdditionalUserLabels:      tpgresource.ExpandStringMap(d, "effective_labels"),
+		AutoscalingAlgorithm:      autoscalingAlgorithm,
+		NumWorkers:                int64(numWorkers),
+		MaxWorkers:                int64(maxNumWorkers),
+		Network:                   network,
+		ServiceAccountEmail:       serviceAccountEmail,
+		Subnetwork:                subnetwork,
+		TempLocation:              tempLocation,
+		StagingLocation:           stagingLocation,
+		MachineType:               machineType,
+		KmsKeyName:            	   kmsKeyName,
+		IpConfiguration:           ipConfiguration,
+		EnableStreamingEngine:     enableStreamingEngine,
+		AdditionalExperiments:     additionalExperiments,
+		AdditionalPipelineOptions: additionalPipelineOptions,
+		SdkContainerImage:         sdkContainerImage,
+		LauncherMachineType:       launcherMachineType,
 	}
 	return env, updatedParameters, nil
 }

--- a/google-beta/services/dataflow/resource_dataflow_flex_template_job_meta.yaml
+++ b/google-beta/services/dataflow/resource_dataflow_flex_template_job_meta.yaml
@@ -5,6 +5,7 @@ api_version: 'v1beta3'
 api_resource_type_kind: 'Job'
 fields:
   - field: 'additional_experiments'
+  - field: 'additional_pipeline_options'
   - field: 'autoscaling_algorithm'
   - field: 'container_spec_gcs_path'
   - field: 'effective_labels'

--- a/google-beta/services/dataflow/resource_dataflow_flex_template_job_test.go
+++ b/google-beta/services/dataflow/resource_dataflow_flex_template_job_test.go
@@ -373,6 +373,40 @@ func TestAccDataflowFlexTemplateJob_withAdditionalExperiments(t *testing.T) {
 	})
 }
 
+func TestAccDataflowFlexTemplateJob_withAdditionalPipelineOptions(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	randStr := acctest.RandString(t, 10)
+	job := "tf-test-dataflow-job-" + randStr
+	additionalPipelineOptions := []string{"numberOfWorkerHarnessThreads=300", "diskSizeGb=500"}
+	bucket := "tf-test-dataflow-bucket-" + randStr
+	topic := "tf-test-topic" + randStr
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataflowFlexTemplateJob_additionalPipelineOptions(job, bucket, topic, additionalPipelineOptions),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_pipeline_options", false),
+					testAccDataflowFlexTemplateJobHasAdditionalPipelineOptions(t, "google_dataflow_flex_template_job.flex_job_pipeline_options", additionalPipelineOptions, false),
+				),
+			},
+			{
+				ResourceName:            "google_dataflow_flex_template_job.flex_job_pipeline_options",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "additional_pipeline_options", "container_spec_gcs_path", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func TestAccDataflowFlexTemplateJob_withProviderDefaultLabels(t *testing.T) {
 	// This resource uses custom retry logic that cannot be sped up without
 	// modifying the actual resource
@@ -669,6 +703,47 @@ func testAccDataflowFlexTemplateJobHasAdditionalExperiments(t *testing.T, res st
 			}
 			if contains != true {
 				return fmt.Errorf("Expected experiment '%s' not found in experiments", expectedExperiment)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataflowFlexTemplateJobHasAdditionalPipelineOptions(t *testing.T, res string, pipelineOptions []string, wait bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[res]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", res)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := acctest.GoogleProviderConfig(t)
+
+		job, err := config.NewDataflowClient(config.UserAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).View("JOB_VIEW_ALL").Do()
+		if err != nil {
+			return fmt.Errorf("dataflow job does not exist")
+		}
+
+		sdkPipelineOptions := job.Environment.SdkPipelineOptions
+		actualPipelineOptionsList := make([]string, len(sdkPipelineOptions))
+
+		// Converting []byte to []string to compare the pipeline options
+		for i, pipelineOption := range sdkPipelineOptions {
+			actualPipelineOptionsList[i] = string(pipelineOption)
+		}
+
+		for _, expectedPipelineOption := range pipelineOptions {
+			var contains = false
+			for _, actualPipelineOption := range actualPipelineOptionsList {
+				if actualPipelineOption == expectedPipelineOption {
+					contains = true
+				}
+			}
+			if contains != true {
+				return fmt.Errorf("Expected pipeline option '%s' not found in additionalPipelineOptions", expectedPipelineOption)
 			}
 		}
 
@@ -1418,6 +1493,61 @@ resource "google_dataflow_flex_template_job" "flex_job_experiments" {
 
 }
 `, topicName, bucket, job, strings.Join(experiments, `", "`))
+}
+
+func testAccDataflowFlexTemplateJob_additionalPipelineOptions(job, bucket, topicName string, pipelineOptions []string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "example" {
+	name = "%s"
+}
+
+resource "google_storage_bucket" "bucket" {
+  name = "%s"
+  location = "US-CENTRAL1"
+  force_destroy = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "schema" {
+  name = "schema.json"
+  bucket = google_storage_bucket.bucket.name
+  content = <<EOF
+{
+	"eventId": "{{uuid()}}",
+	"eventTimestamp": {{timestamp()}},
+	"ipv4": "{{ipv4()}}",
+	"ipv6": "{{ipv6()}}",
+	"country": "{{country()}}",
+	"username": "{{username()}}",
+	"quest": "{{random("A Break In the Ice", "Ghosts of Perdition", "Survive the Low Road")}}",
+	"score": {{integer(100, 10000)}},
+	"completed": {{bool()}}
+}
+EOF
+}
+
+data "google_storage_bucket_object" "flex_template" {
+  name   = "latest/flex/Streaming_Data_Generator"
+  bucket = "dataflow-templates"
+}
+resource "google_dataflow_flex_template_job" "flex_job_pipeline_options" {
+  name = "%s"
+  container_spec_gcs_path = "gs://${data.google_storage_bucket_object.flex_template.bucket}/${data.google_storage_bucket_object.flex_template.name}"
+  on_delete = "cancel"
+  parameters = {
+    schemaLocation = "gs://${google_storage_bucket_object.schema.bucket}/schema.json"
+    qps = "1"
+    topic = google_pubsub_topic.example.id
+  }
+  labels = {
+   "my_labels" = "value"
+  }
+  additional_pipeline_options = ["%s"]
+
+}
+`, topicName, bucket, job, strings.Join(pipelineOptions, `", "`))
 }
 
 func testAccDataflowFlexTemplateJob_withProviderDefaultLabels(job, bucket, topicName, randStr string) string {


### PR DESCRIPTION
Added support for new flag additionalPipelineOptions - https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.locations.flexTemplates/launch#:~:text=additionalPipelineOptions%5B%5D,flags%20for%20the%20job.