### PR TITLE
Clarify 'status' field as required in documentation

### DIFF
--- a/website/docs/r/data_loss_prevention_discovery_config.html.markdown
+++ b/website/docs/r/data_loss_prevention_discovery_config.html.markdown
@@ -554,8 +554,8 @@ The following arguments are supported:
   Structure is [documented below](#nested_targets).
 
 * `status` -
-  (Optional)
-  Required. A status for this configuration
+  (Required)
+  A status for this configuration
   Possible values are: `RUNNING`, `PAUSED`.
 
 


### PR DESCRIPTION
Fixed the status field description to indicate it is required.