### PR TITLE
ci: declare permissions on go, pull-request-size, teamcity-nightly, upstream-mm

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Test

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -2,6 +2,9 @@ name: "Pull Request Size Labeler"
 
 on: [pull_request]
 
+permissions:
+  pull-requests: write   # codelytv/pr-size-labeler labels the PR
+
 jobs:
   labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -8,6 +8,10 @@ on:
         - cron: '0 19 * * *' # 7PM PST
           timezone: 'America/Los_Angeles'
 
+# The reusable workflow creates a nightly-test branch from main.
+permissions:
+    contents: write
+
 jobs:
     # uses the same teamcity nightly workflow used in terraform-provider-google
     # as well as the default value for DAYS_THRESHOLD

--- a/.github/workflows/upstream-mm.yml
+++ b/.github/workflows/upstream-mm.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 
+# Only posts an issue comment on the PR; runs in pull_request_target context.
+permissions:
+  pull-requests: write
+
 jobs:
   pr-warning:
     if: ${{ github.actor != 'modular-magician' }}


### PR DESCRIPTION
Adds explicit `permissions:` blocks to the four workflows still inheriting org defaults. Per-workflow rationale:

- **go.yml** — `contents: read`. Read-only go build/test on push to main + PRs.
- **pull-request-size.yml** — `pull-requests: write`. `codelytv/pr-size-labeler@v1.8.1` applies one of `xs/s/m/l/xl` labels based on diff size.
- **teamcity-nightly-workflow.yaml** — `contents: write`. Caller for the reusable `hashicorp/terraform-provider-google` workflow that creates the nightly-test branch off main for TeamCity to point at.
- **upstream-mm.yml** — `pull-requests: write`. `actions/github-script` posts a warning comment on any PR from a non-modular-magician user to flag that the repo is generated by magic-modules. Runs in `pull_request_target` context so explicit scope is especially valuable.

YAML validated locally.