### PR TITLE
ci: update dependencies for GoTest workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.31.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: "go.mod"
 


### PR DESCRIPTION
Update the GoTest workflow. Expect Node 20 deprecation warnings to disappear.

Assisted-by: GitHub Copilot. Prompt:
```
review the reusable workflows used in this repo's GoTest workflow. 
for any workflows that are running on Node.js 20, propose workflow 
version updates to safely move to a version that supports Node.js 24.
```

