### PR TITLE
release: read secrets from 'release' environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           path: release-notes.txt
           retention-days: 1
   terraform-provider-release:
+    environment: release
     name: 'Terraform Provider Release'
     needs: [release-notes]
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v4.2.1


### PR DESCRIPTION
This change is a required update for secrets in GitHub Actions workflows. CI secrets are migrating from repository secrets to a narrower scope: environment secrets.

The `'release'` environment in this repository contains the secrets necessary for the release workflow, and this commit ensures continuity when repository secrets are subsequently removed.

I will open a PR into terraform-provider-google, too.