### PR TITLE
Grant write permission for teamcity-nightly-workflow to handle branches

### DIFF
--- a/.github/workflows/teamcity-nightly-workflow.yaml
+++ b/.github/workflows/teamcity-nightly-workflow.yaml
@@ -8,6 +8,9 @@ on:
         - cron: '0 19 * * *' # 7PM PST
           timezone: 'America/Los_Angeles'
 
+permissions:
+  contents: write # Required to create, rename, and delete branches
+
 jobs:
     # uses the same teamcity nightly workflow used in terraform-provider-google
     # as well as the default value for DAYS_THRESHOLD


### PR DESCRIPTION
Grant explicit `contents: write` permission (similar to https://github.com/hashicorp/terraform-provider-google/pull/28599), as permissions are not inherited from the GA workflow