### PR TITLE
Revert "release: read secrets from 'release' environment (#12751)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
           path: release-notes.txt
           retention-days: 1
   terraform-provider-release:
-    environment: release
     name: 'Terraform Provider Release'
     needs: [release-notes]
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v4.2.1


### PR DESCRIPTION
This reverts commit f0c471b9102b1e5b6aed02a6f5631906a18198bd.

Mirrors the PR introduced here on release https://github.com/hashicorp/terraform-provider-google-beta/pull/12828